### PR TITLE
Upgraded to netstandard2.1

### DIFF
--- a/MiniGuid.Test/MiniGuid.Test.csproj
+++ b/MiniGuid.Test/MiniGuid.Test.csproj
@@ -1,17 +1,17 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>net8</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
-    <PackageReference Include="Shouldly" Version="2.8.3" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Shouldly" Version="4.2.1" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/MiniGuid/MiniGuid.cs
+++ b/MiniGuid/MiniGuid.cs
@@ -136,7 +136,12 @@ namespace MiniGuids
                 return true;
             }
 
-            if (input.Length != 26) return false;
+            
+            if (input.Length != 26)
+            {
+                guid = new MiniGuid(Guid.Empty);
+                return false;
+            }
 
             var guidBytes = new byte[16];
             var bitWriter = new BitWriter(new BinaryWriter(new MemoryStream(guidBytes)));
@@ -145,7 +150,11 @@ namespace MiniGuids
             {
                 var c = input[i];
                 var chunk = _char2Bin[c];
-                if (!chunk.HasValue) return false;
+                if (!chunk.HasValue)
+                {
+                    guid = new MiniGuid(Guid.Empty);
+                    return false;
+                }
 
                 bitWriter.Write(chunk.Value, 5);
             }
@@ -153,7 +162,11 @@ namespace MiniGuids
             {
                 var c = input[25];
                 var chunk = _char2Bin[c];
-                if (!chunk.HasValue) return false;
+                if (!chunk.HasValue) 
+                {
+                    guid = new MiniGuid(Guid.Empty);
+                    return false;
+                }
 
                 bitWriter.Write(chunk.Value, 3);
             }                                       

--- a/MiniGuid/MiniGuid.csproj
+++ b/MiniGuid/MiniGuid.csproj
@@ -1,22 +1,28 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <PackageId>MiniGuid</PackageId>
-    <Version>1.1.2</Version>
-    <Description>Guids that render as 26-char alphabetic strings - like ShortGuid, but better</Description>
-    <PackageTags>guid;shortguid;short;guids;miniguids;shortguids</PackageTags>
-    <PackageProjectUrl>https://github.com/jasonholloway/miniguid</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/jasonholloway/miniguid</RepositoryUrl>
-    <PackageLicenseUrl>https://opensource.org/licenses/MIT</PackageLicenseUrl>
-    <Copyright>Copyright ©2018 Jason Holloway</Copyright>
-    <RootNamespace>MiniGuids</RootNamespace>
-    <IncludeSource>False</IncludeSource>
-    <IncludeSymbols>True</IncludeSymbols>
-    <TargetFramework>netstandard2.1</TargetFramework>
-  </PropertyGroup>
+	<PropertyGroup>
+		<PackageId>MiniGuid</PackageId>
+		<Version>1.1.3</Version>
+		<Description>Guids that render as 26-char alphabetic strings - like ShortGuid, but better</Description>
+		<PackageTags>guid;shortguid;short;guids;miniguids;shortguids</PackageTags>
+		<PackageProjectUrl>https://github.com/jasonholloway/miniguid</PackageProjectUrl>
+		<RepositoryUrl>https://github.com/jasonholloway/miniguid</RepositoryUrl>
+		<PackageLicenseUrl>https://opensource.org/licenses/MIT</PackageLicenseUrl>
+		<Copyright>Copyright ©2024 Jason Holloway</Copyright>
+		<RootNamespace>MiniGuids</RootNamespace>
+		<IncludeSource>False</IncludeSource>
+		<IncludeSymbols>True</IncludeSymbols>
+		<TargetFrameworks>netstandard2.1;netstandard1.0</TargetFrameworks>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
-  </ItemGroup>
+	<ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.0'">
+		<PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
+		<PackageReference Include="System.Linq" Version="4.3.0" />
+		<PackageReference Include="System.ValueTuple" Version="4.4.0" />
+	</ItemGroup>
+
+	<ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
+		<PackageReference Include="System.ValueTuple" Version="4.5.0" />
+	</ItemGroup>
 
 </Project>

--- a/MiniGuid/MiniGuid.csproj
+++ b/MiniGuid/MiniGuid.csproj
@@ -12,13 +12,11 @@
     <RootNamespace>MiniGuids</RootNamespace>
     <IncludeSource>False</IncludeSource>
     <IncludeSymbols>True</IncludeSymbols>
-    <TargetFramework>netstandard1.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
-    <PackageReference Include="System.Linq" Version="4.3.0" />
-    <PackageReference Include="System.ValueTuple" Version="4.4.0" />
+    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Upgraded library to netstandard2.1
- Removed unneeded package references
- Fixed the "CS0177 The out parameter 'guid' must be assigned to before control leaves the current method" error

Upgraded Test to net8
- Upgraded dependencies to current versions